### PR TITLE
fix npm dependency versions and override local bower resolver

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+	"registry": "https://registry.bower.io",
+	"resolvers": []
+}

--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-	"registry": "https://registry.bower.io",
-	"resolvers": []
-}

--- a/package.json
+++ b/package.json
@@ -19,17 +19,17 @@
   },
   "homepage": "https://github.com/starmind/ui-driver-vmwarevcd#readme",
   "devDependencies": {
-    "del": "^2.2.0",
-    "gulp": "^3.9.1",
-    "gulp-clean": "^0.3.2",
-    "gulp-concat": "^2.6.0",
-    "gulp-connect": "^3.2.2",
+    "del": "2.2.0",
+    "gulp": "3.9.1",
+    "gulp-clean": "0.3.2",
+    "gulp-concat": "2.6.0",
+    "gulp-connect": "3.2.2",
     "gulp-htmlbars-compiler": "0.0.2",
-    "gulp-jshint": "^2.0.0",
-    "gulp-replace": "^0.5.4",
-    "gulp-sourcemaps": "^1.6.0",
-    "gulp-wrap-amd": "^0.5.0",
-    "jshint": "^2.9.1",
-    "yargs": "^4.6.0"
+    "gulp-jshint": "2.0.0",
+    "gulp-replace": "0.5.4",
+    "gulp-sourcemaps": "1.6.0",
+    "gulp-wrap-amd": "0.5.0",
+    "jshint": "2.9.1",
+    "yargs": "4.6.0"
   }
 }


### PR DESCRIPTION
A local `.bowerrc` file is only needed for my setup or maybe yours too as I have it configured globally to use our own Artifactory. (in `~/.bowerrc`)